### PR TITLE
fix(babelify): Run babelify as a global transform when minifying

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,14 +269,15 @@ class Optimize {
 
     /** Browserify babelify transform */
     bundler.transform(babelify, {
+      global: functionMinify,
       presets: functionPresets
     })
 
     /** Browserify minify transform */
     if (functionMinify) {
-      bundler.transform({
+      bundler.transform(uglify, {
         global: true
-      }, uglify)
+      })
     }
 
     /** Generate bundle */


### PR DESCRIPTION
- Since the uglify transform is run as global, it should also be the case for the babelify transform. Otherwise, it fails with ES6 modules.
- Another option would be to always run babelify as a global transform.
- Also refactored bundler.transform for uglify to have same arguments order as babelify.

