### PR TITLE
add external feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Configuration options can be set globally in `custom` property and inside each f
 * **debug** (default `false`) - When debug is set to `true` it won't remove `prefix` folder and will generate debug output at the end of package creation.
 * **exclude** (default `['aws-sdk']`) - Array of modules or paths that will be excluded.
 * **extensions** (default `['.js', '.json']`) - Array of optional extra extensions modules that will be included.
+* **external** Object key value pair of external module name and path. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/sharp && npm i --prod`)
 * **global** (default `false`) - When global is set to `true` transforms will run inside `node_modules`.
 * **ignore** - Array of modules or paths that won't be transformed with Babelify and Uglify.
 * **includePaths** - Array of file paths that will be included in the bundle package. Read [here](#includepaths-files) how to call these files.
@@ -57,6 +58,8 @@ custom:
     debug: true
     exclude: ['ajv']
   	extensions: ['.extension']
+    external:
+      sharp: 'external_modules/sharp'
     global: true
     ignore: ['ajv']
     includePaths: ['bin/some-binary-file']
@@ -78,6 +81,7 @@ functions:
 
 * **exclude** - Array of modules or paths that will be excluded.
 * **extensions** - Array of optional extra extensions modules that will be included.
+* **external** Object key value pair of external module name and path. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/sharp && npm i --prod`)
 * **global** - When global is set to `true` transforms will run inside `node_modules`.
 * **ignore** - Array of modules or paths that won't be transformed with Babelify and Uglify.
 * **includePaths** - Array of file paths that will be included in the bundle package. Read [here](#includepaths-files) how to call these files.
@@ -91,6 +95,8 @@ functions:
     optimize:
       exclude: ['ajv']
       extensions: ['.extension']
+      external:
+        sharp: 'external_modules/sharp'
       global: false
       ignore: ['ajv']
       includePaths: ['bin/some-binary-file']

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Configuration options can be set globally in `custom` property and inside each f
 * **debug** (default `false`) - When debug is set to `true` it won't remove `prefix` folder and will generate debug output at the end of package creation.
 * **exclude** (default `['aws-sdk']`) - Array of modules or paths that will be excluded.
 * **extensions** (default `['.js', '.json']`) - Array of optional extra extensions modules that will be included.
-* **external** Object key value pair of external module name and path. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/sharp && npm i --prod`)
+* **external** Array of modules to be copied into `node_modules` instead of being loaded into browserify bundle. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/some-module && npm i --prod`)
+* **externalPath** Optional object key value pair of external module name and path. If not set, external modules will look for reference path in `node_modules`.
 * **global** (default `false`) - When global is set to `true` transforms will run inside `node_modules`.
 * **ignore** - Array of modules or paths that won't be transformed with Babelify and Uglify.
 * **includePaths** - Array of file paths that will be included in the bundle package. Read [here](#includepaths-files) how to call these files.
@@ -58,7 +59,8 @@ custom:
     debug: true
     exclude: ['ajv']
   	extensions: ['.extension']
-    external:
+    external: ['sharp']
+    externalPath:
       sharp: 'external_modules/sharp'
     global: true
     ignore: ['ajv']
@@ -81,7 +83,8 @@ functions:
 
 * **exclude** - Array of modules or paths that will be excluded.
 * **extensions** - Array of optional extra extensions modules that will be included.
-* **external** Object key value pair of external module name and path. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/sharp && npm i --prod`)
+* **external** Array of modules to be copied into `node_modules` instead of being loaded into browserify bundle. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/some-module && npm i --prod`)
+* **externalPath** Optional object key value pair of external module name and path. If not set, external modules will look for reference path in `node_modules`.
 * **global** - When global is set to `true` transforms will run inside `node_modules`.
 * **ignore** - Array of modules or paths that won't be transformed with Babelify and Uglify.
 * **includePaths** - Array of file paths that will be included in the bundle package. Read [here](#includepaths-files) how to call these files.
@@ -95,7 +98,8 @@ functions:
     optimize:
       exclude: ['ajv']
       extensions: ['.extension']
-      external:
+      external: ['sharp']
+      externalPath:
         sharp: 'external_modules/sharp'
       global: false
       ignore: ['ajv']

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "browserify": "^13.1.1",
     "bluebird": "^3.4.6",
     "fs-extra": "^0.30.0",
+    "resolve-from": "^2.0.0",
     "uglifyify": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
After having problems with sharp module myself, I thought having browserify external feature might come handy for situations like this. 

### sharp bundling example
1. After [creating a sharp deployment package](http://sharp.dimens.io/en/stable/install/#aws-lambda), also install it's dependencies within `node_modules/sharp` (`cd node_modules/sharp && npm i --prod`).
2. Copy `node_modules/sharp` directory to your dev environment, outside of function's `node_modules` directory. For this example, let's assume we have it placed at `external-modules/sharp`.
3. Add the following to `serverless.yml` under global or function settings.
```yml
  optimize:
    external:
      sharp: "external-modules/sharp"
```
4. In result, sharp module installed under function's node_modules will be opted out of browserify bundle and the deployment package we created in step 1 will be copied to `_optimize/[function_name]/node_modules/sharp` when function is packaged.

### notes
- External modules will be copied only if it is listed under a function's dependency (in package.json), so it should be safe to have external modules added to global settings.
- Works with multiple external modules
