### PR TITLE
docs: make `external` usage more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Configuration options can be set globally in `custom` property and inside each f
 * **debug** (default `false`) - When debug is set to `true` it won't remove `prefix` folder and will generate debug output at the end of package creation.
 * **exclude** (default `['aws-sdk']`) - Array of modules or paths that will be excluded.
 * **extensions** (default `['.js', '.json']`) - Array of optional extra extensions modules that will be included.
-* **external** Array of modules to be copied into `node_modules` instead of being loaded into browserify bundle. Note that external modules will require it's dependencies within it's directory. (`cd external_modules/some-module && npm i --prod`)
+* **external** Array of modules to be copied into `node_modules` instead of being loaded into browserify bundle. Note that external modules will require that its dependencies are within its directory and this plugin *will not* do this for you. e.g. you should execute the following: (`cd external_modules/some-module && npm i --prod`)
 * **externalPath** Optional object key value pair of external module name and path. If not set, external modules will look for reference path in `node_modules`.
 * **global** (default `false`) - When global is set to `true` transforms will run inside `node_modules`.
 * **ignore** - Array of modules or paths that won't be transformed with Babelify.


### PR DESCRIPTION
The current docs can be misinterpreted to read that the plugin will install the prod deps for you:

> Note that external modules will require it's dependencies within it's directory.

I've clarified the wording to make it explicit that the developer should actually do this.