### PR TITLE
fix: add support for nodejs10.x runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ class Optimize {
         nodeVersion = this.serverless.service.provider.runtime.split('nodejs')[1];
       }
       
+      if(nodeVersion.endsWith(".x")) {
+        nodeVersion = nodeVersion.replace(/\.x$/, '');
+      }
+      
       /** Optimize variables with default options */
       this.optimize = {
         functions: [],

--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,17 @@ class Optimize {
     const validRunTime = (!this.serverless.service.provider.runtime ||
       this.serverless.service.provider.runtime === 'nodejs4.3' ||
       this.serverless.service.provider.runtime === 'nodejs6.10' ||
-      this.serverless.service.provider.runtime === 'nodejs8.10')
+      this.serverless.service.provider.runtime === 'nodejs8.10' ||
+      this.serverless.service.provider.runtime === 'nodejs10.x')
 
     /** AWS provider and valid runtime check */
     if (validRunTime) {
+      let nodeVersion = "current";
+      
+      if(this.serverless.service.provider.runtime) {
+        nodeVersion = this.serverless.service.provider.runtime.split('nodejs')[1];
+      }
+      
       /** Optimize variables with default options */
       this.optimize = {
         functions: [],
@@ -64,7 +71,7 @@ class Optimize {
           prefix: '_optimize',
           presets: [[require.resolve('@babel/preset-env'), {
             targets: {
-              node: this.serverless.service.provider.runtime.split('nodejs')[1]
+              node: nodeVersion
             }
           }]]
         }


### PR DESCRIPTION
I've update the version check to add support for nodejs 10.x, and made it so that it won't throw an exception when the provider runtime isn't present.