### PR TITLE
Expose browserify sourcemap feature in plugin interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Configuration options can be set globally in `custom` property and inside each f
 * **plugins** - Array of Babel plugins.
 * **prefix** (default `_optimize`) - Folder to output bundle.
 * **presets** (default `['env']`) - Array of Babel presets.
+* **sourceMaps** (default `false`) - when set to `true` an inline sourcemap is generated. This improves stack trace error messages for minified source files. To enable Lambda to use the generated sourcemap you need to enable the feature using the environment variable `NODE_OPTIONS: --enable-source-maps`.
 
 ```yml
 custom:
@@ -71,6 +72,7 @@ custom:
     prefix: 'dist'
     plugins: ['transform-decorators-legacy']
     presets: ['es2017']
+    sourceMaps: true
 ```
 
 #### Function
@@ -93,6 +95,7 @@ functions:
 * **minify** - When minify is set to `false` Babili preset won't be added.
 * **plugins** - Array of Babel plugins.
 * **presets** - Array of Babel presets.
+* **sourceMaps** (default `false`) - when set to `true` an inline sourcemap is generated. This improves stack trace error messages for minified source files. To enable Lambda to use the generated sourcemap you need to enable the feature using the environment variable `NODE_OPTIONS: --enable-source-maps`.
 
 ```yml
 functions:
@@ -109,6 +112,7 @@ functions:
       minify: false
       plugins: ['transform-decorators-legacy']
       presets: ['es2017']
+      sourceMaps: true
 ```
 
 #### includePaths Files

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,8 @@ class Optimize {
             targets: {
               node: nodeVersion
             }
-          }]]
+          }]],
+          sourceMaps: false
         }
       }
 
@@ -143,6 +144,11 @@ class Optimize {
         /** Babel presets */
         if (Array.isArray(this.custom.optimize.presets)) {
           this.optimize.options.presets = this.custom.optimize.presets
+        }
+
+        /** Source maps */
+        if (typeof this.custom.optimize.sourceMaps === 'boolean') {
+          this.optimize.options.sourceMaps = this.custom.optimize.sourceMaps
         }
       }
 
@@ -323,7 +329,8 @@ class Optimize {
       ignore: this.optimize.options.ignore,
       minify: this.optimize.options.minify,
       plugins: this.optimize.options.plugins,
-      presets: this.optimize.options.presets
+      presets: this.optimize.options.presets,
+      sourceMaps: this.optimize.options.sourceMaps
     }
 
     if (functionObject.optimize) {
@@ -393,7 +400,8 @@ class Optimize {
         global: undefined,
         'Buffer.isBuffer': undefined,
         Buffer: undefined
-      }
+      },
+      debug: functionOptions.sourceMaps
     })
 
     /** Browserify exclude */


### PR DESCRIPTION
This feature allows users to output a sourcemap with the generated minified file.

This will then lead to stack traces pointing to lines in the original source files, this makes working on errors much nicer.

Source maps with NodeJS in Lambda is available from version 12, to configure it you need to also enable the NodeJS option using an environment variable like this: `NODE_OPTIONS: --enable-source-maps`