### PR TITLE
Extend validation schema for function properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,31 @@ class Optimize {
         'after:invoke:local:invoke': this.afterCreateDeploymentArtifacts.bind(this),
         'before:invoke:local:invoke': this.beforeCreateDeploymentArtifacts.bind(this)
       }
+      
+      /* Extend schema validation for function properties */
+      const arrayOfStringsSchema = { type: 'array', items: { type: 'string' } }
+      serverless.configSchemaHandler.defineFunctionProperties(serverless.service.provider.name, {
+        type: 'object',
+        properties: {
+          optimize: {
+            type: ['boolean', 'object'],
+            properties: {
+              debug: { type: 'boolean' },
+              exclude: arrayOfStringsSchema,
+              external: arrayOfStringsSchema,
+              externalPaths: { type: 'object' },
+              extensions: arrayOfStringsSchema,
+              global: { type: 'boolean' },
+              includePaths: arrayOfStringsSchema,
+              ignore: arrayOfStringsSchema,
+              minify: { type: 'boolean' },
+              plugins: arrayOfStringsSchema,
+              prefix: { type: 'string' },
+              presets: arrayOfStringsSchema
+            }
+          }
+        }
+      })
     }
   }
 


### PR DESCRIPTION
I was seeing a lot of warnings about my configuration that looked like `unrecognized property 'optimize'` because serverless now requests that plugins provide schema to validate configuration. It warns that serverless will default to throwing on these kinds of warnings in the future so I added a schema definition.

Not 100% sure about the schema for all options but this satisfied the config warnings from serverless for me. Hope this is a start.