### PR TITLE
Add node 16 and serverless 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Serverless Optimize Plugin
 =============================
-[![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com) 
+[![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 [![npm version](https://badge.fury.io/js/serverless-plugin-optimize.svg)](https://badge.fury.io/js/serverless-plugin-optimize)
 [![npm downloads](https://img.shields.io/npm/dm/serverless-plugin-optimize.svg)](https://www.npmjs.com/package/serverless-plugin-optimize)
 [![license](https://img.shields.io/npm/l/serverless-plugin-optimize.svg)](https://raw.githubusercontent.com/FidelLimited/serverless-plugin-optimize/master/LICENSE)
@@ -11,7 +11,7 @@ This plugin is a child of the great [serverless-optimizer-plugin](https://github
 
 **Requirements:**
 * Serverless *v1.12.x* or higher.
-* AWS provider and nodejs4.3/6.10/8.10/10.x/12.x/14.x runtimes
+* AWS provider and nodejs4.3/6.10/8.10/10.x/12.x/14.x/16.x runtimes
 
 ## Setup
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ class Optimize {
       this.serverless.service.provider.runtime === 'nodejs8.10' ||
       this.serverless.service.provider.runtime === 'nodejs10.x' ||
       this.serverless.service.provider.runtime === 'nodejs12.x' ||
-      this.serverless.service.provider.runtime === 'nodejs14.x')
+      this.serverless.service.provider.runtime === 'nodejs14.x' ||
+      this.serverless.service.provider.runtime === 'nodejs16.x')
 
     /** AWS provider and valid runtime check */
     if (validRunTime) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,31 @@ class Optimize {
     this.options = options
     this.custom = this.serverless.service.custom
 
+    if (this.serverless.version.startsWith('3')) {
+      this.serverless.configSchemaHandler.defineFunctionProperties(
+        'aws',
+        {
+          properties: {
+            optimize: {
+              type: ['object', 'boolean'],
+              properties: {
+                exclude: {type: 'array'},
+                extensions: {type: 'array'},
+                external: {type: 'array'},
+                externalPaths: {type: 'object'},
+                global: {type: 'boolean'},
+                ignore: {type: 'array'},
+                includePaths: {type: 'array'},
+                minify: {type: 'boolean'},
+                plugins: {type: 'array'},
+                presets: {type: 'array'},
+              }
+            }
+          }
+        }
+      )
+    }
+
     this.provider = this.serverless.getProvider('aws')
 
     /** Runtime >=node4.3 */

--- a/src/index.js
+++ b/src/index.js
@@ -45,16 +45,36 @@ class Optimize {
             optimize: {
               type: ['object', 'boolean'],
               properties: {
-                exclude: {type: 'array'},
-                extensions: {type: 'array'},
-                external: {type: 'array'},
-                externalPaths: {type: 'object'},
-                global: {type: 'boolean'},
-                ignore: {type: 'array'},
-                includePaths: {type: 'array'},
-                minify: {type: 'boolean'},
-                plugins: {type: 'array'},
-                presets: {type: 'array'},
+                exclude: {
+                  type: 'array'
+                },
+                extensions: {
+                  type: 'array'
+                },
+                external: {
+                  type: 'array'
+                },
+                externalPaths: {
+                  type: 'object'
+                },
+                global: {
+                  type: 'boolean'
+                },
+                ignore: {
+                  type: 'array'
+                },
+                includePaths: {
+                  type: 'array'
+                },
+                minify: {
+                  type: 'boolean'
+                },
+                plugins: {
+                  type: 'array'
+                },
+                presets: {
+                  type: 'array'
+                }
               }
             }
           }


### PR DESCRIPTION
Adds in Node 16 compatibility now that [AWS supports it](https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/)
Adds in a [schema for Serverless 3 compatibility](https://www.serverless.com/framework/docs/guides/plugins/custom-configuration) 